### PR TITLE
fix: use `|` for multi-line text in yaml 

### DIFF
--- a/assets/css/features.css
+++ b/assets/css/features.css
@@ -7,7 +7,6 @@
 }
 .feature {
   width: 100%;
-  padding: 1rem;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -15,7 +14,7 @@
 }
 .child {
   width: 100%;
-  padding: .5rem 2rem;
+  padding: .5rem;
 }
 .feature-title {
   font-size: 1.4rem;
@@ -31,8 +30,12 @@
 @media screen and (min-width: 720px) {
   .child {
     width: 50%;
+    padding: .5rem 2rem;
   }
   .feature:nth-child(2n+1) .child:nth-child(2n+1) {
     order: 1;
+  }
+  .feature {
+    padding: 1rem;
   }
 }

--- a/content/_index.md
+++ b/content/_index.md
@@ -10,7 +10,7 @@ image: logos/ignite_logo.svg
 
 features:
   - title: Simple Engine and Event System
-    details: Trigger any handlers at any built-in and custom events
+    details: Trigger any handlers at any built-in and custom events.
     code: >
       ```py {linenos=false}
         from ignite.engine import Engine, Events

--- a/content/_index.md
+++ b/content/_index.md
@@ -17,7 +17,7 @@ features:
 
       trainer = Engine(lambda engine, batch: batch / 2)
       @trainer.on(Events.ITERATION_COMPLETED(every=2))
-      def print(engine):
+      def print_output(engine):
           print(engine.state.output)
       ```
   - title: Rich Handlers

--- a/content/_index.md
+++ b/content/_index.md
@@ -11,91 +11,91 @@ image: logos/ignite_logo.svg
 features:
   - title: Simple Engine and Event System
     details: Trigger any handlers at any built-in and custom events.
-    code: >
+    code: |
       ```py {linenos=false}
-        from ignite.engine import Engine, Events
+      from ignite.engine import Engine, Events
 
-        trainer = Engine(lambda engine, batch: batch / 2)
-        @trainer.on(Events.ITERATION_COMPLETED(every=2))
-        def print(engine):
-            print(engine.state.output)
+      trainer = Engine(lambda engine, batch: batch / 2)
+      @trainer.on(Events.ITERATION_COMPLETED(every=2))
+      def print(engine):
+          print(engine.state.output)
       ```
   - title: Rich Handlers
     details: Checkpointing, early stopping, profiling, parameter scheduling, learning rate finder, and more.
-    code: >
+    code: |
       ```py {linenos=false}
-        from ignite.engine import Engine, Events
-        from ignite.handlers import ModelCheckpoint, EarlyStopping, PiecewiseLinear
+      from ignite.engine import Engine, Events
+      from ignite.handlers import ModelCheckpoint, EarlyStopping, PiecewiseLinear
 
-        model = nn.Linear(3, 3)
-        trainer = Engine(lambda engine, batch: None)
+      model = nn.Linear(3, 3)
+      trainer = Engine(lambda engine, batch: None)
 
-        # model checkpoint handler
-        checkpoint = ModelChckpoint('/tmp/ckpts', 'training')
-        trainer.add_event_handler(Events.EPOCH_COMPLETED(every=2), handler, {'model': model})
+      # model checkpoint handler
+      checkpoint = ModelChckpoint('/tmp/ckpts', 'training')
+      trainer.add_event_handler(Events.EPOCH_COMPLETED(every=2), handler, {'model': model})
 
-        # early stopping handler
-        def score_function(engine):
-            val_loss = engine.state.metrics['acc']
-            return val_loss
-        es = EarlyStopping(3, score_function, trainer)
-        # Note: the handler is attached to an *Evaluator* (runs one epoch on validation dataset).
-        evaluator.add_event_handler(Events.COMPLETED, handler)
+      # early stopping handler
+      def score_function(engine):
+          val_loss = engine.state.metrics['acc']
+          return val_loss
+      es = EarlyStopping(3, score_function, trainer)
+      # Note: the handler is attached to an *Evaluator* (runs one epoch on validation dataset).
+      evaluator.add_event_handler(Events.COMPLETED, handler)
 
-        # Piecewise linear parameter scheduler
-        scheduler = PiecewiseLinear(optimizer, 'lr', [(10, 0.5), (20, 0.45), (21, 0.3), (30, 0.1), (40, 0.1)])
-        trainer.add_event_handler(Events.ITERATION_STARTED, scheduler)
+      # Piecewise linear parameter scheduler
+      scheduler = PiecewiseLinear(optimizer, 'lr', [(10, 0.5), (20, 0.45), (21, 0.3), (30, 0.1), (40, 0.1)])
+      trainer.add_event_handler(Events.ITERATION_STARTED, scheduler)
       ```
   - title: Distributed Training
     details: Speed up the training on CPUs, GPUs, and TPUs.
-    code: >
+    code: |
       ```py {linenos=false}
-        import ignite.distributed as idist
+      import ignite.distributed as idist
 
-        def training(local_rank, *args, **kwargs):
-            dataloder_train = idist.auto_dataloder(dataset, ...)
+      def training(local_rank, *args, **kwargs):
+          dataloder_train = idist.auto_dataloder(dataset, ...)
 
-            model = ...
-            model = idist.auto_model(model)
+          model = ...
+          model = idist.auto_model(model)
 
-            optimizer = ...
-            optimizer = idist.auto_optimizer(optimizer)
+          optimizer = ...
+          optimizer = idist.auto_optimizer(optimizer)
 
-        backend = 'nccl'  # or 'gloo', 'horovod', 'xla-tpu'
-        with idist.Parallel(backend) as parallel:
-            parallel.run(training)
+      backend = 'nccl'  # or 'gloo', 'horovod', 'xla-tpu'
+      with idist.Parallel(backend) as parallel:
+          parallel.run(training)
       ```
   - title: 50+ metrics
     details: Distributed ready out-of-the-box metrics to easily evaluate models.
-    code: >
+    code: |
       ```py {linenos=false}
-        from ignite.engine import Engine
-        from ignite.metrics import Accuracy
+      from ignite.engine import Engine
+      from ignite.metrics import Accuracy
 
-        trainer = Engine(...)
-        acc = Accuracy()
-        acc.attach(trainer, 'accuracy')
-        state = engine.run(data)
-        print(f"Accuracy: {state.metrics['accuracy']}")
+      trainer = Engine(...)
+      acc = Accuracy()
+      acc.attach(trainer, 'accuracy')
+      state = engine.run(data)
+      print(f"Accuracy: {state.metrics['accuracy']}")
       ```
   - title: Rich Integration with Experiment Managers
     details: Tensorboard, MLFlow, WandB, Neptune, and more.
-    code: >
+    code: |
       ```py {linenos=false}
-        from ignite.engine import Engine, Events
-        from ignite.contrib.handlers.tensorboard_logger import TensorboardLogger
+      from ignite.engine import Engine, Events
+      from ignite.contrib.handlers.tensorboard_logger import TensorboardLogger
 
-        trainer = Engine(...)
+      trainer = Engine(...)
 
-        # Create a tensorboard logger
-        with TensorboardLogger(log_dir="experiments/tb_logs") as tb_logger:
-            # Attach the logger to the trainer to log training loss at each iteration
-            tb_logger.attach_output_handler(
-              trainer,
-              event_name=Events.ITERATION_COMPLETED,
-              tag="training",
-              output_transform=lambda loss: {"loss": loss}
-            )
+      # Create a tensorboard logger
+      with TensorboardLogger(log_dir="experiments/tb_logs") as tb_logger:
+          # Attach the logger to the trainer to log training loss at each iteration
+          tb_logger.attach_output_handler(
+            trainer,
+            event_name=Events.ITERATION_COMPLETED,
+            tag="training",
+            output_transform=lambda loss: {"loss": loss}
+          )
       ```
 
 sponsors:


### PR DESCRIPTION
Current deployed site has white-space on features block.
I wrongly used the yaml `>` for multi-line texts. It should be `|`.

![Screen Shot 2021-08-24 at 21 04 50](https://user-images.githubusercontent.com/32727188/130636161-379ad22f-5430-4a91-a6a1-18caaafb9ac0.png)
