### PR TITLE
fix(search): search on both website & docs

### DIFF
--- a/themes/ignite/layouts/partials/BodyEnd.html
+++ b/themes/ignite/layouts/partials/BodyEnd.html
@@ -43,7 +43,7 @@
         apiKey: '19a7a7a75d87608d6f42c722ed1e293f',
         indexName: 'ignite',
         searchParameters: {
-          facetFilters: [`version:${val.tag_name}`]
+          facetFilters: [[`version:${val.tag_name}`, 'tags:ignite-web']]
         }
       })
     })

--- a/themes/ignite/layouts/partials/SideBar.html
+++ b/themes/ignite/layouts/partials/SideBar.html
@@ -31,7 +31,7 @@
   <div class="border-b lg:hidden dark:border-dark-200">{{ partial "NavBar.html" . }}</div>
   <nav class="py-3 px-1">
     {{ if eq .Section "blog" }}
-      <h5 class="font-semibold py-1 uppercase">{{ .Section }}</h5>
+      <h5 class="font-semibold py-1 uppercase">{{ .Section | title }}</h5>
       <ul class="px-2 pb-4">
         {{ range where .Site.RegularPages "Section" .Section }}
         <li class="py-1">


### PR DESCRIPTION
This PR enables latest ignite version search on docs and website.
Related algolia config PR to view : https://github.com/algolia/docsearch-configs/pull/4658

Ignite config: https://github.com/algolia/docsearch-configs/blob/master/configs/ignite.json
facetFilters docs (this PR using OR filter): https://www.algolia.com/doc/api-reference/api-parameters/facetFilters/#simple-or-filter