### PR TITLE
fix(search): add active class in sidebar title

### DIFF
--- a/themes/ignite/layouts/partials/SideBar.html
+++ b/themes/ignite/layouts/partials/SideBar.html
@@ -6,6 +6,7 @@
 <!-- prettier-ignore -->
 */}}
 {{ $url := .RelPermalink }}
+{{ $section := .Section }}
 
 <aside
   class="
@@ -58,7 +59,14 @@
     {{ else }}
       {{ range .Site.Sections }}
         {{ if in (slice "tutorials" "how-to-guides") .Section }}
-          <h5 class="font-semibold py-1 uppercase">{{ .Section }}</h5>
+          <h5 class="
+            font-semibold
+            py-1
+            uppercase
+            {{ if eq $section .Section }}active{{ end }}"
+            >
+              {{ .Section | title }}
+          </h5>
           <ul class="px-2 pb-4">
           {{ range where .Site.RegularPages "Section" .Section }}
             <li class="py-1">

--- a/themes/ignite/layouts/partials/SideBar.html
+++ b/themes/ignite/layouts/partials/SideBar.html
@@ -32,7 +32,7 @@
   <div class="border-b lg:hidden dark:border-dark-200">{{ partial "NavBar.html" . }}</div>
   <nav class="py-3 px-1">
     {{ if eq .Section "blog" }}
-      <h5 class="font-semibold py-1 uppercase">{{ .Section | title }}</h5>
+      <h5 class="font-semibold py-1 uppercase active">{{ .Section | title }}</h5>
       <ul class="px-2 pb-4">
         {{ range where .Site.RegularPages "Section" .Section }}
         <li class="py-1">


### PR DESCRIPTION
If we are viewing under `Tutorials` and `How-to-Guides`, this PR adds `active` class which will be used in docsearch to show the docsearch hits title.