### PR TITLE
fix: scroll on main doc even if sidebar is opened

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # pytorch-ignite.ai
 
+[![Netlify Status](https://api.netlify.com/api/v1/badges/07834561-3160-4177-b8f7-69e9439a6e95/deploy-status)](https://app.netlify.com/sites/pytorch-ignite/deploys)
+
 This website is built with [Hugo](https://gohugo.io). You will need to install the extended version of Hugo 0.88.1.
 
 > Blog posts relating to PyTorch-Ignite are welcomed for pull requests.

--- a/themes/ignite/assets/_hugo/js/main.js
+++ b/themes/ignite/assets/_hugo/js/main.js
@@ -6,7 +6,6 @@ function openSideBar() {
     const sidebar = document.getElementById('sidebar')
 
     sideBarBtn.addEventListener('click', function () {
-      document.documentElement.classList.toggle('overflow-hidden')
       sidebar.classList.toggle('translate-x-0')
     })
   }


### PR DESCRIPTION
To test this on mobile:
Open the sidebar and try scrolling, main doc will be scrolled after scrolling in sidebar ended.