### PR TITLE
chore: add discord shortcut link

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -74,6 +74,12 @@ HUGO_ENV = "production"
   force = true
 
 [[redirects]]
+  from = "/chat"
+  to = "https://discord.gg/djZtm3EmKj"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/*"
   to = "/404.html"
   status = 404


### PR DESCRIPTION
So we now can use https://pytorch-ignite.ai/chat instead of discord link.