### PR TITLE
fix: open as external links

### DIFF
--- a/themes/ignite/layouts/index.html
+++ b/themes/ignite/layouts/index.html
@@ -218,6 +218,8 @@
     {{ range $footer }}
     <a
       href="{{ .url }}"
+      target="_blank"
+      rel="noopener noreferrer"
       class="mx-2 text-blue-gray-400 inline-block hover:text-blue-gray-500"
     >
       <span class="sr-only">{{ .name }}</span>


### PR DESCRIPTION
Social links in footer should open in new windows.