### PR TITLE
Adding governance page ( About us section)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -51,5 +51,7 @@ params:
           link: /about/coc/
         - text: Talks
           link: /talks/
+        - text: Governance
+          link: /about/governance/
     - text: GitHub
       link: https://github.com/pytorch/ignite

--- a/src/about/governance.md
+++ b/src/about/governance.md
@@ -1,0 +1,51 @@
+---
+title: "Governance"
+description: PyTorch-Ignite Governance Page
+---
+
+PyTorch-Ignite Governance
+=========================
+
+The purpose of this document is to formalize the governance process used
+by the PyTorch-Ignite project, to clarify how decisions are made and how
+the various elements of our community interact. This document
+establishes a decision-making structure that takes into account feedback
+from all members of the community and strives to find consensus, while
+avoiding any deadlocks.
+
+This is a meritocratic, consensus-based community project. Anyone with
+an interest in the project can join the community, contribute to the
+project design and participate in the decision making process. This
+document describes how that participation takes place and how to set
+about earning merit within the project community.
+
+Roles And Responsibilities
+--------------------------
+
+### Contributors
+
+Contributors are community members who contribute in concrete ways to
+the project. Anyone can become a contributor, and contributions can take
+many forms as detailed in the [contributors
+guide](https://github.com/pytorch/ignite/blob/master/CONTRIBUTING.md).
+
+### Core developers
+
+Core developers are community members who have shown their continued
+implication in the project through ongoing engagement with the community
+and contributions. They have shown they can be trusted to maintain
+PyTorch-Ignite with care. Being a core developer allows contributors to
+more easily carry on with their project related activities by giving
+them direct access to the project's repository and is represented as
+being an organization member on the PyTorch-Ignite GitHub organization.
+
+Core developers are expected to review code contributions, can merge
+approved pull requests, can cast votes for and against merging a
+pull-request, and can be involved in deciding major changes to the API.
+
+New core developers can be nominated by any existing core developers.
+
+Core developers that have not contributed to the project (commits or
+GitHub comments) in the past 2 months will be asked if they want to
+become emeritus core developers and recant their commit rights until
+they become active again.


### PR DESCRIPTION
Description: As title.

I've added the governance page (in the about us section) to reflect the same page in the old website (https://pytorch.org/ignite/governance.html) 

Adding this as we are migrating the documentation pages and that page was missing in the new website.