### PR TITLE
Add PyTorch Adapt to ecosystem.md

### DIFF
--- a/src/ecosystem.md
+++ b/src/ecosystem.md
@@ -52,6 +52,7 @@ The list below is unexhausted list of references that we are aware of.
 - [DeepSeismic - Deep Learning for Seismic Imaging and Interpretation](https://github.com/microsoft/seismic-deeplearning)
 - [Nussl - a flexible, object-oriented Python audio source separation library](https://github.com/nussl/nussl)
 - [xFraud: Explainable Fraud Transaction Detection on Heterogeneous Graphs](https://github.com/eBay/xFraud)
+- [PyTorch Adapt - A fully featured and modular domain adaptation library](https://github.com/KevinMusgrave/pytorch-adapt)
 
 ## Others
 


### PR DESCRIPTION
This PR adds PyTorch Adapt (a new domain adaptation library) to ecosystem.md

Relevant links:

- [The main place where Ignite is used in the library](https://github.com/KevinMusgrave/pytorch-adapt/blob/main/src/pytorch_adapt/frameworks/ignite/ignite.py)

- [Example usage for end users](https://github.com/KevinMusgrave/pytorch-adapt/blob/main/examples/getting_started/DANNIgniteWithViz.ipynb)
